### PR TITLE
static mixin (protocol level)

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2562,7 +2562,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
   {
     size_t n_unmixable = 0, n_mixable = 0;
     size_t mixin = std::numeric_limits<size_t>::max();
-    const size_t min_mixin = hf_version >= HF_VERSION_MIN_MIXIN_9 ? 9 : hf_version >= HF_VERSION_MIN_MIXIN_7 ? 7 : hf_version >= HF_VERSION_MIN_MIXIN_4 ? 4 : 2;
+    const size_t min_mixin = hf_version >= HF_VERSION_MIN_MIXIN_7 ? 7 : hf_version >= HF_VERSION_MIN_MIXIN_4 ? 4 : 2;
     for (const auto& txin : tx.vin)
     {
       // non txin_to_key inputs will be rejected below
@@ -2591,6 +2591,9 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       }
     }
 
+  // from v9, mixin is static
+  if (hf_version < HF_VERSION_MIN_MIXIN_9)
+  {
     if (mixin < min_mixin)
     {
       if (n_unmixable == 0)
@@ -2606,7 +2609,18 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         return false;
       }
     }
-
+    else 
+    {
+      const size_t mixin = DEFAULT_MIXIN;
+      const size_t min_mixin = DEFAULT_MIXIN;
+      if (mixin != min_mixin)
+      {
+        MERROR_VER("Tx " << get_transaction_hash(tx) << " has invalid ring size");
+        return false;
+      }
+    }
+  } 
+  
     // min/max tx version based on HF, and we accept v1 txes if having a non mixable
     const size_t max_tx_version = (hf_version <= 3) ? 1 : 2;
     if (tx.version > max_tx_version)


### PR DESCRIPTION
After hard fork version 9, all transactions must have the same ring size.