### PR TITLE
allow sync over tor

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -345,7 +345,9 @@ namespace cryptonote
     }
 
     // No chain synchronization over hidden networks (tor, i2p, etc.)
-    if(context.m_remote_address.get_zone() != epee::net_utils::zone::public_)
+    // if(context.m_remote_address.get_zone() != epee::net_utils::zone::public_)
+    // wow wow wow ...
+    if (false)
     {
       context.m_state = cryptonote_connection_context::state_normal;
       return true;
@@ -2384,7 +2386,7 @@ skip:
     std::vector<std::pair<epee::net_utils::zone, boost::uuids::uuid>> fullConnections, fluffyConnections;
     m_p2p->for_each_connection([this, &exclude_context, &fullConnections, &fluffyConnections](connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)
     {
-      if (peer_id && exclude_context.m_connection_id != context.m_connection_id && context.m_remote_address.get_zone() == epee::net_utils::zone::public_)
+      if (peer_id && exclude_context.m_connection_id != context.m_connection_id)
       {
         if(m_core.fluffy_blocks_enabled() && (support_flags & P2P_SUPPORT_FLAG_FLUFFY_BLOCKS))
         {

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -313,7 +313,8 @@ namespace nodetool
             break;
         }
 
-        if (address.get_zone() == epee::net_utils::zone::public_)
+        // nice try
+        // if (address.get_zone() == epee::net_utils::zone::public_)
             return false;
 
         MWARNING("Filtered command (#" << command << ") to/from " << address.str());

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -135,6 +135,7 @@ namespace nodetool
       m_peerlist_storage = std::move(*storage);
 
     m_network_zones[epee::net_utils::zone::public_].m_config.m_support_flags = P2P_SUPPORT_FLAGS;
+    m_network_zones[epee::net_utils::zone::tor].m_config.m_support_flags = P2P_SUPPORT_FLAGS;
     m_first_connection_maker_call = true;
 
     CATCH_ENTRY_L0("node_server::init_config", false);
@@ -2159,8 +2160,8 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::try_get_support_flags(const p2p_connection_context& context, std::function<void(p2p_connection_context&, const uint32_t&)> f)
   {
-    if(context.m_remote_address.get_zone() != epee::net_utils::zone::public_)
-      return false;
+    // if(context.m_remote_address.get_zone() != epee::net_utils::zone::public_)
+    //   return false;
 
     COMMAND_REQUEST_SUPPORT_FLAGS::request support_flags_request;
     bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_REQUEST_SUPPORT_FLAGS::response>


### PR DESCRIPTION
The goal is to allow users to not run a dual stack when desired.