### PR TITLE
comment out v16 fork

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -178,7 +178,7 @@
 #define HF_VERSION_REJECT_SIGS_IN_COINBASE      15
 #define HF_VERSION_ENFORCE_MIN_AGE              15
 #define HF_VERSION_EFFECTIVE_SHORT_TERM_MEDIAN_IN_PENALTY 15
-#define HF_VERSION_SHA3_POW                     16 // Block 288,888 ~8 February 2021
+#define HF_VERSION_SHA3_POW                     16 // Block 288,888 ~8 February 2021, depends on availability of open source sha-3 fpga designs
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 

--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -41,7 +41,7 @@ const hardfork_t mainnet_hard_forks[] = {
   { 13, 114969, 0, 1559292691 },
   { 14, 115257, 0, 1559292774 },
   { 15, 160777, 0, 1573280497 },
-  { 16, 288888, 0, 1589210508 },
+  //{ 16, 288888, 0, 1589210508 },
 };
 const size_t num_mainnet_hard_forks = sizeof(mainnet_hard_forks) / sizeof(mainnet_hard_forks[0]);
 


### PR DESCRIPTION
Since forking to sha-3 depends on the availability of open source sha-3 fpga designs and circumstances could change a year from now, it would be best to comment out the fork height to avoid network problems if we change our minds. Once we are more sure about switching to sha-3 pow, we could make a mandatory update point release later.